### PR TITLE
Add Buildkite CI pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,3 +19,4 @@ steps:
     plugins:
       - docker#v5.11.0:
           image: "ruby:4.0.1-alpine"
+          propagate-uid-gid: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,12 @@
 steps:
+  - label: ":docker: Docker Login"
+    key: docker-login
+    command:
+      - buildkite-agent secret get DOCKERHUB_VAYU_TOKEN | docker login -u $$(buildkite-agent secret get DOCKERHUB_VAYU_USERNAME) --password-stdin
+
   - label: ":jekyll: Build & Audit"
     key: build
+    depends_on: docker-login
     timeout_in_minutes: 20
     command:
       - bundle install --with ci --without development
@@ -10,9 +16,6 @@ steps:
     artifact_paths:
       - _site.tar.gz
     plugins:
-      - docker-login#v3.0.0:
-          username-env: DOCKERHUB_VAYU_USERNAME
-          password-env: DOCKERHUB_VAYU_TOKEN
       - docker#v5.11.0:
           image: "ruby:4.0.1"
 
@@ -26,8 +29,5 @@ steps:
       - gem install html-proofer
       - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
     plugins:
-      - docker-login#v3.0.0:
-          username-env: DOCKERHUB_VAYU_USERNAME
-          password-env: DOCKERHUB_VAYU_TOKEN
       - docker#v5.11.0:
           image: "ruby:4.0.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,33 @@
+steps:
+  - label: ":jekyll: Build"
+    key: build
+    command:
+      - bundle install --with ci --without development
+      - bundle exec jekyll build
+      - tar czf _site.tar.gz _site/
+    artifact_paths:
+      - _site.tar.gz
+    plugins:
+      - docker#v5.11.0:
+          image: "ruby:4.0.1"
+
+  - label: ":mag: HTML Validation"
+    key: html-validation
+    depends_on: build
+    command:
+      - buildkite-agent artifact download _site.tar.gz .
+      - tar xzf _site.tar.gz
+      - gem install html-proofer
+      - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
+    plugins:
+      - docker#v5.11.0:
+          image: "ruby:4.0.1"
+
+  - label: ":lock: Vulnerability Audit"
+    key: vulnerability-audit
+    command:
+      - gem install bundler-audit
+      - bundle audit check --update
+    plugins:
+      - docker#v5.11.0:
+          image: "ruby:4.0.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     command:
       - buildkite-agent secret get DOCKERHUB_VAYU_TOKEN | docker login -u $$(buildkite-agent secret get DOCKERHUB_VAYU_USERNAME) --password-stdin
 
-  - label: ":jekyll: Build & Audit"
+  - label: ":jekyll: Build, Validate & Audit"
     key: build
     depends_on: docker-login
     timeout_in_minutes: 20
@@ -15,18 +15,7 @@ steps:
       - bundle install
       - bundle audit check --update
       - bundle exec jekyll build
-      - tar czf _site.tar.gz _site/
-    artifact_paths:
-      - _site.tar.gz
+      - bundle exec htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
     plugins:
       - docker#v5.11.0:
           image: "ruby:4.0.1-alpine"
-
-  - label: ":mag: HTML Validation"
-    key: html-validation
-    depends_on: build
-    timeout_in_minutes: 20
-    command:
-      - buildkite-agent artifact download _site.tar.gz .
-      - tar xzf _site.tar.gz
-      - docker run --rm -v "$$PWD/_site:/site" ruby:4.0.1-alpine sh -c "gem install html-proofer && htmlproofer /site --ignore-urls '/^http:/' --no-enforce-https --allow-missing-href"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,19 +4,16 @@ steps:
     command:
       - buildkite-agent secret get DOCKERHUB_VAYU_TOKEN | docker login -u $$(buildkite-agent secret get DOCKERHUB_VAYU_USERNAME) --password-stdin
 
-  - label: ":jekyll: Build, Validate & Audit"
+  - label: ":jekyll: Build & Audit"
     key: build
     depends_on: docker-login
     timeout_in_minutes: 20
     command:
       - apk add --no-cache git build-base libffi-dev
-      - bundle config set with 'ci'
       - bundle config set without 'development'
       - bundle install
       - bundle audit check --update
       - bundle exec jekyll build
-      - bundle exec htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
     plugins:
       - docker#v5.11.0:
           image: "ruby:4.0.1-alpine"
-          propagate-uid-gid: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       - _site.tar.gz
     plugins:
       - docker-login#v3.0.0:
-          username: vayu
+          username-env: DOCKERHUB_VAYU_USERNAME
           password-env: DOCKERHUB_VAYU_TOKEN
       - docker#v5.11.0:
           image: "ruby:4.0.1"
@@ -27,7 +27,7 @@ steps:
       - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
     plugins:
       - docker-login#v3.0.0:
-          username: vayu
+          username-env: DOCKERHUB_VAYU_USERNAME
           password-env: DOCKERHUB_VAYU_TOKEN
       - docker#v5.11.0:
           image: "ruby:4.0.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,9 @@ steps:
     artifact_paths:
       - _site.tar.gz
     plugins:
+      - docker-login#v3.0.0:
+          username: vayu
+          password-env: DOCKERHUB_VAYU_TOKEN
       - docker#v5.11.0:
           image: "ruby:4.0.1"
 
@@ -23,5 +26,8 @@ steps:
       - gem install html-proofer
       - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
     plugins:
+      - docker-login#v3.0.0:
+          username: vayu
+          password-env: DOCKERHUB_VAYU_TOKEN
       - docker#v5.11.0:
           image: "ruby:4.0.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
     depends_on: docker-login
     timeout_in_minutes: 20
     command:
-      - apk add --no-cache git build-base
+      - apk add --no-cache git build-base libffi-dev
       - bundle config set with 'ci'
       - bundle config set without 'development'
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
       - _site.tar.gz
     plugins:
       - docker#v5.11.0:
-          image: "ruby:4.0.1"
+          image: "ruby:4.0.1-alpine"
 
   - label: ":mag: HTML Validation"
     key: html-validation
@@ -30,4 +30,4 @@ steps:
       - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
     plugins:
       - docker#v5.11.0:
-          image: "ruby:4.0.1"
+          image: "ruby:4.0.1-alpine"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,7 @@
 steps:
   - label: ":jekyll: Build & Audit"
     key: build
+    timeout_in_minutes: 20
     command:
       - bundle install --with ci --without development
       - bundle audit check --update
@@ -15,6 +16,7 @@ steps:
   - label: ":mag: HTML Validation"
     key: html-validation
     depends_on: build
+    timeout_in_minutes: 20
     command:
       - buildkite-agent artifact download _site.tar.gz .
       - tar xzf _site.tar.gz

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,9 @@ steps:
     depends_on: docker-login
     timeout_in_minutes: 20
     command:
-      - bundle install --with ci --without development
+      - bundle config set with 'ci'
+      - bundle config set without 'development'
+      - bundle install
       - bundle audit check --update
       - bundle exec jekyll build
       - tar czf _site.tar.gz _site/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ steps:
     depends_on: docker-login
     timeout_in_minutes: 20
     command:
+      - apk add --no-cache git build-base
       - bundle config set with 'ci'
       - bundle config set without 'development'
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,9 @@
 steps:
-  - label: ":jekyll: Build"
+  - label: ":jekyll: Build & Audit"
     key: build
     command:
       - bundle install --with ci --without development
+      - bundle audit check --update
       - bundle exec jekyll build
       - tar czf _site.tar.gz _site/
     artifact_paths:
@@ -19,15 +20,6 @@ steps:
       - tar xzf _site.tar.gz
       - gem install html-proofer
       - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
-    plugins:
-      - docker#v5.11.0:
-          image: "ruby:4.0.1"
-
-  - label: ":lock: Vulnerability Audit"
-    key: vulnerability-audit
-    command:
-      - gem install bundler-audit
-      - bundle audit check --update
     plugins:
       - docker#v5.11.0:
           image: "ruby:4.0.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,8 +29,4 @@ steps:
     command:
       - buildkite-agent artifact download _site.tar.gz .
       - tar xzf _site.tar.gz
-      - gem install html-proofer
-      - htmlproofer _site --ignore-urls "/^http:/" --no-enforce-https --allow-missing-href
-    plugins:
-      - docker#v5.11.0:
-          image: "ruby:4.0.1-alpine"
+      - docker run --rm -v "$$PWD/_site:/site" ruby:4.0.1-alpine sh -c "gem install html-proofer && htmlproofer /site --ignore-urls '/^http:/' --no-enforce-https --allow-missing-href"

--- a/Gemfile
+++ b/Gemfile
@@ -54,5 +54,4 @@ end
 
 group :ci do
   gem 'bundler-audit'
-  gem 'html-proofer'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -51,3 +51,8 @@ group :development do
   gem 'mastodon-api'
   gem 'openssl', '4.0.0'
 end
+
+group :ci do
+  gem 'bundler-audit'
+  gem 'html-proofer'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,18 +19,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (2.0.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    afm (1.0.0)
-    async (2.36.0)
-      console (~> 1.29)
-      fiber-annotation
-      io-event (~> 1.11)
-      metrics (~> 0.12)
-      traces (~> 0.18)
     base64 (0.3.0)
-    benchmark (0.5.0)
     bigdecimal (3.1.8)
     buftok (0.3.0)
     bundler-audit (0.9.3)
@@ -38,39 +29,18 @@ GEM
       thor (~> 1.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
-    console (1.34.2)
-      fiber-annotation
-      fiber-local (~> 1.1)
-      json
     csv (3.3.5)
     domain_name (0.6.20240107)
     dotenv (3.2.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
-      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.17.0)
-    fiber-annotation (0.2.0)
-    fiber-local (1.1.0)
-      fiber-storage
-    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
-    hashery (2.1.2)
-    html-proofer (5.2.0)
-      addressable (~> 2.3)
-      async (~> 2.1)
-      benchmark (~> 0.5)
-      nokogiri (~> 1.13)
-      pdf-reader (~> 2.11)
-      rainbow (~> 3.0)
-      typhoeus (~> 1.3)
-      yell (~> 2.0)
-      zeitwerk (~> 2.5)
     http (3.3.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -82,7 +52,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    io-event (1.14.2)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -109,7 +78,6 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.18.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -125,12 +93,7 @@ GEM
       http (~> 3.3)
       oj (~> 3.7)
     mercenary (0.4.0)
-    metrics (0.15.0)
-    mini_portile2 (2.8.9)
     nio4r (2.7.4)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     oj (3.16.13)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -138,19 +101,11 @@ GEM
     ostruct (0.6.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pdf-reader (2.15.1)
-      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
-      afm (>= 0.2.1, < 2)
-      hashery (~> 2.0)
-      ruby-rc4
-      ttfunk
     public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
-    racc (1.8.1)
     rack (3.2.4)
     rack-ssl-enforcer (0.2.9)
-    rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -159,7 +114,6 @@ GEM
     rouge (4.5.1)
     rss (0.3.2)
       rexml
-    ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.80.7)
       google-protobuf (~> 4.28)
@@ -167,15 +121,8 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.5.0)
-    traces (0.18.2)
-    ttfunk (1.8.0)
-      bigdecimal (~> 3.1)
-    typhoeus (1.5.0)
-      ethon (>= 0.9.0, < 0.16.0)
     unicode-display_width (2.6.0)
     webrick (1.9.0)
-    yell (2.2.2)
-    zeitwerk (2.7.4)
 
 PLATFORMS
   ruby
@@ -186,7 +133,6 @@ DEPENDENCIES
   bundler-audit
   csv
   dotenv
-  html-proofer
   jekyll (= 4.3.3)
   jekyll-feed
   jekyll-paginate-v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,25 +19,58 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    afm (1.0.0)
+    async (2.36.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (3.1.8)
     buftok (0.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
+    console (1.34.2)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.5)
     domain_name (0.6.20240107)
     dotenv (3.2.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.17.0)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
+    hashery (2.1.2)
+    html-proofer (5.2.0)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http (3.3.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -49,6 +82,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    io-event (1.14.2)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -75,6 +109,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.18.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -90,7 +125,12 @@ GEM
       http (~> 3.3)
       oj (~> 3.7)
     mercenary (0.4.0)
+    metrics (0.15.0)
+    mini_portile2 (2.8.9)
     nio4r (2.7.4)
+    nokogiri (1.19.0)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     oj (3.16.13)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -98,27 +138,44 @@ GEM
     ostruct (0.6.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
-    rack (3.1.8)
+    racc (1.8.1)
+    rack (3.2.4)
     rack-ssl-enforcer (0.2.9)
+    rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rouge (4.5.1)
     rss (0.3.2)
       rexml
+    ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.80.7)
       google-protobuf (~> 4.28)
       rake (>= 13)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thor (1.5.0)
+    traces (0.18.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
+    typhoeus (1.5.0)
+      ethon (>= 0.9.0, < 0.16.0)
     unicode-display_width (2.6.0)
     webrick (1.9.0)
+    yell (2.2.2)
+    zeitwerk (2.7.4)
 
 PLATFORMS
   ruby
@@ -126,8 +183,10 @@ PLATFORMS
 DEPENDENCIES
   base64
   bigdecimal
+  bundler-audit
   csv
   dotenv
+  html-proofer
   jekyll (= 4.3.3)
   jekyll-feed
   jekyll-paginate-v2


### PR DESCRIPTION
## Summary
- Adds `bundler-audit` and `html-proofer` gems to Gemfile (in a `:ci` group)
- Creates `.buildkite/pipeline.yml` with three steps:
  - **Build** — installs gems and runs `jekyll build`, uploads `_site/` as artifact
  - **HTML Validation** — runs `htmlproofer` against the built site (broken links, missing alt tags, valid HTML)
  - **Vulnerability Audit** — runs `bundle audit` to check for gems with known CVEs
- All steps use the `ruby:4.0.1` Docker image via the Buildkite Docker plugin

## Test plan
- [ ] Verify pipeline YAML is loaded by Buildkite
- [ ] Confirm build step completes and uploads artifact
- [ ] Confirm HTML validation step runs against the built site
- [ ] Confirm vulnerability audit step reports results